### PR TITLE
🐛 fix player side-edge color in white mode with theater mode

### DIFF
--- a/app/styles/_inc/outsideStyle.scss
+++ b/app/styles/_inc/outsideStyle.scss
@@ -11,7 +11,6 @@
   // Resizing container size.
   #player-container {
     height: calc(100% + var(--oypb-player-bar-height)) !important;
-    background-color: var(--yt-main-app-background-tmp) !important;
     overflow: hidden; // Substitution of `html5-player-video`'s overflow (repair sideeffect: e.g. `ytp-ce-shadow`)
   }
 


### PR DESCRIPTION
過去のYoutubeの仕様で、動画プレイヤーの背景をテーマの色(css-variablesに依存)で上書きしていたせい。

非ダークモードではvarが白色なのでそれが動画背景に反映されてしまっていた。