### PR TITLE
Fix sometimes unstable when open video on new tab

### DIFF
--- a/src/core/mains/stateDriven/__reflectFunctionality__.ts
+++ b/src/core/mains/stateDriven/__reflectFunctionality__.ts
@@ -1,9 +1,9 @@
+import { waitMainWorldReady } from "@/core/mains/stateDriven/operationStateDriven.js";
 import { __reflectFunctionalityState__ } from "@/core/repositories/contentScript.repository.js";
 import { manageAlwaysDisplayPlayerBar } from "@/core/services/behaviorServices/alwaysDisplayPlayerBar.service.js";
 import { movePlayerBarElement } from "@/core/services/domAffectServices/playerBarDomAffect.service.js";
-import { snapshot, subscribe } from "valtio/vanilla";
-
 import { Mutex } from "async-mutex";
+import { snapshot, subscribe } from "valtio/vanilla";
 
 const mutex = new Mutex();
 
@@ -20,6 +20,7 @@ export const reflectFunctionality = () => {
 
 		await mutex
 			.runExclusive(async () => {
+				await waitMainWorldReady();
 				await Promise.allSettled([
 					movePlayerBarElement({
 						direction: feature.behavior.positionPlayerBar,

--- a/src/core/mains/stateDriven/operationStateDriven.ts
+++ b/src/core/mains/stateDriven/operationStateDriven.ts
@@ -1,3 +1,4 @@
+import { getFlagOps } from "@/core/presenters/statePresenter/operationState/index.js";
 import { operationState } from "@/core/repositories/contentScript.repository.js";
 import { domAffectOypbEnable } from "@/core/services/domAffectServices/domMetaAffect.service.js";
 import { subscribeKey } from "valtio/utils";
@@ -8,3 +9,33 @@ export const oypbEnableDriven = () => {
 		domAffectOypbEnable(value);
 	});
 };
+
+export function waitMainWorldReady() {
+	const { promise, resolve } = Promise.withResolvers<void>();
+	const unsubscribe = subscribeKey(
+		operationState.flagOps,
+		"mainWorld",
+		({ scriptReady: isReady }) => {
+			if (isReady) {
+				logger.debug("MainWorld standby");
+				unsubscribe();
+				resolve();
+			}
+		},
+	);
+
+	const {
+		mainWorld: { scriptReady: isReady },
+	} = getFlagOps();
+
+	if (isReady) {
+		unsubscribe();
+		setTimeout(() => {
+			logger.debug("MainWorld already standby.");
+			resolve();
+		}, 0);
+	}
+
+	logger.debug("waiting MainWorld ready…");
+	return promise;
+}

--- a/src/core/services/behaviorServices/alwaysDisplayPlayerBar.service.ts
+++ b/src/core/services/behaviorServices/alwaysDisplayPlayerBar.service.ts
@@ -103,10 +103,8 @@ export const manageAlwaysDisplayPlayerBar = async ({
 	);
 
 	if (position === "inside") {
-		logger.log("A2", readyMainWorld);
 		dataAttrIsAlwaysDisplayBar.remove();
 		await mainWorldSignals.sendMessage("resetControlState", undefined);
-		logger.log("A2 done");
 
 		return;
 	}
@@ -115,11 +113,7 @@ export const manageAlwaysDisplayPlayerBar = async ({
 		videoPlayerState: { mode },
 	} = getSiteMetaState();
 
-	logger.log("A3", mode);
-
 	const { alwaysDisplayPlayerBar } = await resolveBehaviorOption(mode);
-
-	logger.log("A4", position, alwaysDisplayPlayerBar);
 
 	if (position === "outside" && alwaysDisplayPlayerBar) {
 		dataAttrIsAlwaysDisplayBar.set();


### PR DESCRIPTION
- **chore: remove unnecessary logger**
- **fix: #371 Ensure that you wait for the mainworld to be ready during the reflect phase**
